### PR TITLE
修复log使用与本地化问题

### DIFF
--- a/src/main/java/com/altnoir/poopsky/block/AbstractCompooperBlock.java
+++ b/src/main/java/com/altnoir/poopsky/block/AbstractCompooperBlock.java
@@ -1,5 +1,6 @@
 package com.altnoir.poopsky.block;
 
+import com.altnoir.poopsky.PoopSky;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
@@ -115,7 +116,8 @@ public abstract class AbstractCompooperBlock extends Block {
                             break;
                         }
                     } else {
-                        System.out.println(targetState.getBlock().getName().getString() + " False");
+                        PoopSky.LOGGER.debug("Unable to place compooper block because target block {} cannot be replaced",
+                                targetState.getBlock().getName().getString());
                         break;
                     }
                 }

--- a/src/main/java/com/altnoir/poopsky/item/p/TimeBellItem.java
+++ b/src/main/java/com/altnoir/poopsky/item/p/TimeBellItem.java
@@ -28,9 +28,9 @@ public class TimeBellItem extends Item {
                 level.playSound(null, player.getOnPos(),
                         SoundEvents.EXPERIENCE_ORB_PICKUP, SoundSource.PLAYERS, 1.0F, 1.0F);
 
-                // 发送反馈消息
-                String message = newState ? "已冻结游戏时间" : "已解冻游戏时间";
-                player.sendSystemMessage(Component.literal(message));
+                player.sendSystemMessage(Component.translatable(newState
+                        ? "message.poopsky.time_bell.frozen"
+                        : "message.poopsky.time_bell.unfrozen"));
 
             }
         }

--- a/src/main/resources/assets/poopsky/lang/en_us.json
+++ b/src/main/resources/assets/poopsky/lang/en_us.json
@@ -6,10 +6,13 @@
   "item.poopsky.wither_poop_ball": "Wither Poop Ball",
   "item.poopsky.spall": "Spall",
   "item.poopsky.toilet_plug": "Toilet Plug",
-  "item.poopsky.time_bell": "Time Bell",
   "item.poopsky.urine_bottle": "Urine Bottle",
   "item.poopsky.poop_bucket": "Poop Bucket",
   "block.poopsky.poop_liquid": "Poop Liquid",
+
+  "item.poopsky.time_bell": "Time Bell",
+  "message.poopsky.time_bell.frozen": "Game time frozen",
+  "message.poopsky.time_bell.unfrozen": "Game time unfrozen",
 
   "item.poopsky.toilet_linker": "Toilet Linker",
   "message.poopsky.toilet_linker.1": "Link Toilet ①",
@@ -184,8 +187,8 @@
   "advancements.adventure.poop_block_slide.description": "Slide on a poop block",
 
   "subtitle.poopsky.fart": "Fart Sound",
-  "subtitle.poopsky.villager.work_compooper": "Poopmaker: Working",
-  "subtitle.poopsky.villager.work_toilet": "Gastronome: Eating",
+  "subtitle.poopsky.villager.work_compooper": "Poopmaker works",
+  "subtitle.poopsky.villager.work_toilet": "Gastronome eats",
 
   "tag.item.poopsky.compooper_saplings": "Compooper Saplings",
   "jei.category.poopsky.compooper": "Compooper",

--- a/src/main/resources/assets/poopsky/lang/zh_cn.json
+++ b/src/main/resources/assets/poopsky/lang/zh_cn.json
@@ -6,10 +6,13 @@
   "item.poopsky.wither_poop_ball": "凋灵粪便球",
   "item.poopsky.spall": "碎石",
   "item.poopsky.toilet_plug": "马桶搋子",
-  "item.poopsky.time_bell": "屎溅之铃",
   "item.poopsky.urine_bottle": "尿瓶",
   "item.poopsky.poop_bucket": "粪桶",
   "block.poopsky.poop_liquid": "粪液",
+
+  "item.poopsky.time_bell": "屎溅之铃",
+  "message.poopsky.time_bell.frozen": "已冻结游戏时间",
+  "message.poopsky.time_bell.unfrozen": "已解冻游戏时间",
 
   "item.poopsky.toilet_linker": "厕所连接器",
   "message.poopsky.toilet_linker.1": "连接厕所①",
@@ -108,7 +111,7 @@
   "block.poopsky.poolime_poop_block": "屎莱姆蛆块",
   "block.poopsky.compooper": "堆粪桶",
   "block.poopsky.water_compooper": "装有水的堆粪桶",
-  "block.poopsky.lava_compooper": "装有岩浆的堆粪桶",
+  "block.poopsky.lava_compooper": "装有熔岩的堆粪桶",
   "block.poopsky.power_snow_compooper": "装有细雪的堆粪桶",
   "block.poopsky.urine_compooper": "装有粪的堆粪桶",
 


### PR DESCRIPTION
英语字幕应该尊重原版的格式。参见https://minecraft.wiki/w/Closed_captions 和 [https://vmct-cn.top/rule/固定或已成习惯的表达](https://vmct-cn.top/rule/#%E5%9B%BA%E5%AE%9A%E6%88%96%E5%B7%B2%E6%88%90%E4%B9%A0%E6%83%AF%E7%9A%84%E8%A1%A8%E8%BE%BE)

`岩浆`应为`熔岩`