### PR TITLE
修复一系列bug

### DIFF
--- a/src/main/java/com/altnoir/poopsky/block/AbstractCompooperBlock.java
+++ b/src/main/java/com/altnoir/poopsky/block/AbstractCompooperBlock.java
@@ -184,8 +184,7 @@ public abstract class AbstractCompooperBlock extends Block {
 
     protected void setBlock(BlockState state, Level level, BlockPos pos, Player player, SoundEvent sound) {
         level.playSound(null, pos, sound, SoundSource.BLOCKS, 1.0F, 1.0F);
-        BlockState compooperBlock = PSBlocks.COMPOOPER.get().defaultBlockState();
-        level.setBlockAndUpdate(pos, compooperBlock);
+        level.setBlockAndUpdate(pos, state);
         level.gameEvent(GameEvent.BLOCK_CHANGE, pos, GameEvent.Context.of(player, state));
     }
 

--- a/src/main/java/com/altnoir/poopsky/block/AbstractToiletBlock.java
+++ b/src/main/java/com/altnoir/poopsky/block/AbstractToiletBlock.java
@@ -89,7 +89,11 @@ public abstract class AbstractToiletBlock extends Block implements EntityBlock {
 
     @Override
     protected InteractionResult useWithoutItem(BlockState state, Level level, BlockPos pos, Player player, BlockHitResult hitResult) {
-        if (!level.isClientSide && player.getItemInHand(InteractionHand.MAIN_HAND).isEmpty()) {
+        if (!player.getItemInHand(InteractionHand.MAIN_HAND).isEmpty()) {
+            return InteractionResult.PASS;
+        }
+
+        if (!level.isClientSide) {
             Entity entity;
             List<ToiletEntity> entities = level.getEntities(PSEntityType.TOILET.get(), new AABB(pos), toiletEntity -> true);
 
@@ -100,7 +104,7 @@ public abstract class AbstractToiletBlock extends Block implements EntityBlock {
             }
             player.startRiding(entity);
         }
-        return InteractionResult.PASS;
+        return InteractionResult.sidedSuccess(level.isClientSide);
     }
 
     @Override
@@ -336,7 +340,9 @@ public abstract class AbstractToiletBlock extends Block implements EntityBlock {
         } else {
             connection = ToiletState.DEFAULT;
         }
-        level.setBlockAndUpdate(pos, state.setValue(CONNECTION, connection));
+        if (connection != state.getValue(CONNECTION)) {
+            level.setBlockAndUpdate(pos, state.setValue(CONNECTION, connection));
+        }
     }
 
     protected boolean hasHot(ServerLevel level, BlockPos pos) {

--- a/src/main/java/com/altnoir/poopsky/block/p/UrineCompooperBlock.java
+++ b/src/main/java/com/altnoir/poopsky/block/p/UrineCompooperBlock.java
@@ -106,7 +106,7 @@ public class UrineCompooperBlock extends AbstractCompooperBlock implements World
 
     @Override
     protected void neighborChanged(BlockState state, Level level, BlockPos pos, Block neighborBlock, BlockPos neighborPos, boolean movedByPiston) {
-        if (neighborPos.equals(pos.below()) && state.getValue(LEVEL) == MAX_LEVEL && isHot((ServerLevel) level, pos)) {
+        if (!level.isClientSide && neighborPos.equals(pos.below()) && state.getValue(LEVEL) == MAX_LEVEL && isHot((ServerLevel) level, pos)) {
             level.scheduleTick(pos, this, 80);
         }
         super.neighborChanged(state, level, pos, neighborBlock, neighborPos, movedByPiston);

--- a/src/main/java/com/altnoir/poopsky/event/GlassBottleEvent.java
+++ b/src/main/java/com/altnoir/poopsky/event/GlassBottleEvent.java
@@ -62,11 +62,13 @@ public class GlassBottleEvent {
             BlockPos blockpos = blockhitresult.getBlockPos();
 
             if (blockhitresult.getType() == HitResult.Type.BLOCK && level.mayInteract(player, blockpos) && level.getFluidState(blockpos).is(PSFluids.POOP.get())) {
-                level.playSound(player, player.getX(), player.getY(), player.getZ(), SoundEvents.BOTTLE_FILL, SoundSource.NEUTRAL, 1.0F, 1.0F);
-                level.gameEvent(player, GameEvent.FLUID_PICKUP, blockpos);
+                if (!level.isClientSide) {
+                    level.playSound(player, player.getX(), player.getY(), player.getZ(), SoundEvents.BOTTLE_FILL, SoundSource.NEUTRAL, 1.0F, 1.0F);
+                    level.gameEvent(player, GameEvent.FLUID_PICKUP, blockpos);
 
-                ItemStack itemStack = ItemUtils.createFilledResult(stack, player, new ItemStack(PSItems.URINE_BOTTLE.get()));
-                player.setItemInHand(event.getHand(), itemStack);
+                    ItemStack itemStack = ItemUtils.createFilledResult(stack, player, new ItemStack(PSItems.URINE_BOTTLE.get()));
+                    player.setItemInHand(event.getHand(), itemStack);
+                }
 
                 event.setCancellationResult(InteractionResult.SUCCESS);
                 event.setCanceled(true);

--- a/src/main/java/com/altnoir/poopsky/item/p/ToiletLinkerItem.java
+++ b/src/main/java/com/altnoir/poopsky/item/p/ToiletLinkerItem.java
@@ -32,12 +32,13 @@ public class ToiletLinkerItem extends PSBaseItem {
     @Override
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand usedHand) {
         var itemstack = player.getItemInHand(usedHand);
-        if (level.isClientSide && !player.isShiftKeyDown())
-            return super.use(level, player, usedHand);
+        if (!player.isShiftKeyDown()) {
+            return InteractionResultHolder.pass(itemstack);
+        }
 
         itemstack.set(PSComponents.TOILET_COMPONENT, ToiletComponent.EMPTY);
         player.displayClientMessage(Component.translatable("message.poopsky.toilet_linker.4").withStyle(style -> style.withColor(0xAA0000)), true);
-        return InteractionResultHolder.success(itemstack);
+        return InteractionResultHolder.sidedSuccess(itemstack, level.isClientSide);
     }
 
     @Override
@@ -107,8 +108,8 @@ public class ToiletLinkerItem extends PSBaseItem {
             toilet1.setChanged();
             toilet2.setChanged();
 
-            level1.getChunkSource().addRegionTicket(TicketType.PORTAL, new ChunkPos(pos2), 1, pos2);
-            level2.getChunkSource().addRegionTicket(TicketType.PORTAL, new ChunkPos(pos1), 1, pos1);
+            level1.getChunkSource().addRegionTicket(TicketType.PORTAL, new ChunkPos(pos1), 1, pos1);
+            level2.getChunkSource().addRegionTicket(TicketType.PORTAL, new ChunkPos(pos2), 1, pos2);
 
             var s1 = level1.getBlockState(pos1);
             var s2 = level2.getBlockState(pos2);

--- a/src/main/java/com/altnoir/poopsky/item/p/ToiletPlugItem.java
+++ b/src/main/java/com/altnoir/poopsky/item/p/ToiletPlugItem.java
@@ -17,11 +17,16 @@ public class ToiletPlugItem extends Item {
 
     @Override
     public @NotNull InteractionResult useOn(UseOnContext context) {
-        if (context.getLevel().isClientSide() || context.getPlayer() == null)
-            return super.useOn(context);
-
         var level = context.getLevel();
         var player = context.getPlayer();
+
+        if (player == null) {
+            return InteractionResult.PASS;
+        }
+
+        if (level.isClientSide()) {
+            return InteractionResult.SUCCESS;
+        }
         var pos = context.getClickedPos();
         var face = context.getClickedFace();
         var stack = context.getItemInHand();
@@ -51,6 +56,6 @@ public class ToiletPlugItem extends Item {
 
         if (!player.isCreative()) stack.shrink(1);
 
-        return super.useOn(context);
+        return InteractionResult.SUCCESS;
     }
 }

--- a/src/main/java/com/altnoir/poopsky/item/p/UrineBottleItem.java
+++ b/src/main/java/com/altnoir/poopsky/item/p/UrineBottleItem.java
@@ -51,16 +51,19 @@ public class UrineBottleItem extends Item {
 
     @Override
     public InteractionResult interactLivingEntity(ItemStack stack, Player player, LivingEntity entity, InteractionHand hand) {
-        if (!player.level().isClientSide) {
-            if (entity.isAlive() && entity instanceof Chicken chicken) {
+        if (entity.isAlive() && entity instanceof Chicken chicken) {
+            if (!player.level().isClientSide) {
                 var waterPotion = PotionContents.createItemStack(Items.POTION, Potions.WATER);
 
                 chicken.playSound(SoundEvents.CHICKEN_EGG);
                 chicken.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SPEED, 1200, 1));
                 chicken.hurt(player.damageSources().playerAttack(player), 1.0F);
-                stack.shrink(1);
+                if (!player.getAbilities().instabuild) {
+                    stack.shrink(1);
+                }
                 entity.spawnAtLocation(waterPotion);
             }
+            return InteractionResult.sidedSuccess(player.level().isClientSide);
         }
         return super.interactLivingEntity(stack, player, entity, hand);
     }


### PR DESCRIPTION
Codex修的一部分，还远不是全部bug，比如副手放马桶搋子按V不会召唤也没修。看起来和测了一下没什么大问题

- 修复堆粪桶抽取液体时总是重置成空普通堆粪桶的问题；现在会保留传入的目标方块状态，避免少量液体被玻璃瓶抽取后直接丢失方块/液位状态。
- 修复空手点击马桶后仍返回 PASS 的交互结果问题，并避免马桶连接状态未变化时反复触发方块更新，减少游戏内交互异常和邻居更新抖动。
- 修复装有粪的堆粪桶在客户端邻居更新时也强转 ServerLevel 的潜在崩溃问题，现在只在服务端检测加热并安排 tick。
- 修复对粪液使用玻璃瓶时客户端直接改玩家物品栏导致的客户端/服务端不同步
- 修复马桶制杖空右键会意外清空已保存链接的问题；现在只有潜行使用才清空，同时修正链接后区块ticket加到错误坐标的问题。
- 修复马桶搋子从放置后仍返回父类结果导致交互看起来失败/不稳定的问题；现在客户端立即成功预测，服务端生成实体并返回成功 
- 修复尿瓶喂鸡交互在创造模式也消耗物品、客户端返回不一致的问题