### PR TITLE
粪便蛋糕 X 赤石科技

### DIFF
--- a/src/main/java/com/altnoir/poopsky/PSItemGroups.java
+++ b/src/main/java/com/altnoir/poopsky/PSItemGroups.java
@@ -8,6 +8,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.registries.DeferredHolder;
@@ -38,6 +39,7 @@ public class PSItemGroups {
                 );
                 PSBlocks.BLOCKS.getEntries().stream()
                         .map(DeferredHolder::get)
+                        .filter(block -> block.asItem() != Items.AIR)
                         .filter(block -> !skip.contains(block))
                         .forEach(output::accept);
 

--- a/src/main/java/com/altnoir/poopsky/block/PSBlocks.java
+++ b/src/main/java/com/altnoir/poopsky/block/PSBlocks.java
@@ -31,6 +31,7 @@ public class PSBlocks {
     public static final DeferredBlock<Block> POOP_CAKE = registerBlock("poop_cake",
             () -> new PoopCakeBlock(poopCakeProperties())
     );
+
     private static final Map<Block, DeferredBlock<Block>> POOP_CANDLE_CAKES = Map.ofEntries(
             registerPoopCandleCake("poop_candle_cake", Blocks.CANDLE),
             registerPoopCandleCake("white_poop_candle_cake", Blocks.WHITE_CANDLE),
@@ -539,8 +540,14 @@ public class PSBlocks {
     }
 
     private static Map.Entry<Block, DeferredBlock<Block>> registerPoopCandleCake(String name, Block candle) {
-        DeferredBlock<Block> candleCake = BLOCKS.register(name, () -> new PoopCandleCakeBlock(candle, poopCakeProperties()
-                .lightLevel(state -> state.getValue(PoopCandleCakeBlock.LIT) ? 3 : 0)));
+        if (!(candle instanceof CandleBlock)) {
+            throw new IllegalArgumentException("Expected candle block: " + candle);
+        }
+
+        DeferredBlock<Block> candleCake = BLOCKS.register(name,
+                () -> new PoopCandleCakeBlock(candle, poopCakeProperties()
+                        .lightLevel(state -> state.getValue(PoopCandleCakeBlock.LIT) ? 3 : 0)));
+
         return Map.entry(candle, candleCake);
     }
 

--- a/src/main/java/com/altnoir/poopsky/block/PSBlocks.java
+++ b/src/main/java/com/altnoir/poopsky/block/PSBlocks.java
@@ -19,6 +19,7 @@ import net.neoforged.bus.api.IEventBus;
 import net.neoforged.neoforge.registries.DeferredBlock;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class PSBlocks {
@@ -28,11 +29,26 @@ public class PSBlocks {
     public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks(PoopSky.MOD_ID);
 
     public static final DeferredBlock<Block> POOP_CAKE = registerBlock("poop_cake",
-            () -> new PoopCakeBlock(BlockBehaviour.Properties.of()
-                    .forceSolidOn()
-                    .strength(0.5F)
-                    .sound(SoundType.WOOL)
-                    .pushReaction(PushReaction.DESTROY))
+            () -> new PoopCakeBlock(poopCakeProperties())
+    );
+    private static final Map<Block, DeferredBlock<Block>> POOP_CANDLE_CAKES = Map.ofEntries(
+            registerPoopCandleCake("poop_candle_cake", Blocks.CANDLE),
+            registerPoopCandleCake("white_poop_candle_cake", Blocks.WHITE_CANDLE),
+            registerPoopCandleCake("orange_poop_candle_cake", Blocks.ORANGE_CANDLE),
+            registerPoopCandleCake("magenta_poop_candle_cake", Blocks.MAGENTA_CANDLE),
+            registerPoopCandleCake("light_blue_poop_candle_cake", Blocks.LIGHT_BLUE_CANDLE),
+            registerPoopCandleCake("yellow_poop_candle_cake", Blocks.YELLOW_CANDLE),
+            registerPoopCandleCake("lime_poop_candle_cake", Blocks.LIME_CANDLE),
+            registerPoopCandleCake("pink_poop_candle_cake", Blocks.PINK_CANDLE),
+            registerPoopCandleCake("gray_poop_candle_cake", Blocks.GRAY_CANDLE),
+            registerPoopCandleCake("light_gray_poop_candle_cake", Blocks.LIGHT_GRAY_CANDLE),
+            registerPoopCandleCake("cyan_poop_candle_cake", Blocks.CYAN_CANDLE),
+            registerPoopCandleCake("purple_poop_candle_cake", Blocks.PURPLE_CANDLE),
+            registerPoopCandleCake("blue_poop_candle_cake", Blocks.BLUE_CANDLE),
+            registerPoopCandleCake("brown_poop_candle_cake", Blocks.BROWN_CANDLE),
+            registerPoopCandleCake("green_poop_candle_cake", Blocks.GREEN_CANDLE),
+            registerPoopCandleCake("red_poop_candle_cake", Blocks.RED_CANDLE),
+            registerPoopCandleCake("black_poop_candle_cake", Blocks.BLACK_CANDLE)
     );
 
     public static final DeferredBlock<Block> POOP_PIECE = registerBlock("poop_piece",
@@ -513,6 +529,25 @@ public class PSBlocks {
                             .pushReaction(PushReaction.DESTROY)
             )
     );
+
+    private static BlockBehaviour.Properties poopCakeProperties() {
+        return BlockBehaviour.Properties.of()
+                .forceSolidOn()
+                .strength(0.5F)
+                .sound(SoundType.WOOL)
+                .pushReaction(PushReaction.DESTROY);
+    }
+
+    private static Map.Entry<Block, DeferredBlock<Block>> registerPoopCandleCake(String name, Block candle) {
+        DeferredBlock<Block> candleCake = BLOCKS.register(name, () -> new PoopCandleCakeBlock(candle, poopCakeProperties()
+                .lightLevel(state -> state.getValue(PoopCandleCakeBlock.LIT) ? 3 : 0)));
+        return Map.entry(candle, candleCake);
+    }
+
+    public static BlockState getPoopCandleCake(CandleBlock candle) {
+        DeferredBlock<Block> candleCake = POOP_CANDLE_CAKES.get(candle);
+        return candleCake == null ? null : candleCake.get().defaultBlockState();
+    }
 
     public static boolean neverSuffocate(BlockState state, BlockGetter world, BlockPos pos) {
         return false;

--- a/src/main/java/com/altnoir/poopsky/block/p/PoopCakeBlock.java
+++ b/src/main/java/com/altnoir/poopsky/block/p/PoopCakeBlock.java
@@ -3,6 +3,7 @@ package com.altnoir.poopsky.block.p;
 import com.altnoir.poopsky.particle.PSParticles;
 import com.altnoir.poopsky.block.PSBlocks;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
@@ -10,6 +11,7 @@ import net.minecraft.stats.Stats;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.ItemInteractionResult;
+import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.player.Player;
@@ -84,15 +86,16 @@ public class PoopCakeBlock extends CakeBlock {
                         3.0
                 );
             }
-            player.addEffect(new MobEffectInstance(MobEffects.LUCK, 1800, 1), player);
-            player.addEffect(new MobEffectInstance(MobEffects.CONFUSION, 100, 0), player);
-            player.addEffect(new MobEffectInstance(MobEffects.BLINDNESS, 20, 0), player);
-            player.addEffect(new MobEffectInstance(MobEffects.DARKNESS, 60, 0), player);
+
+            addOrExtendEffect(player, MobEffects.LUCK, 1800, 1);
+            addOrExtendEffect(player, MobEffects.CONFUSION, 100, 0);
+            addOrExtendEffect(player, MobEffects.BLINDNESS, 20, 0);
+            addOrExtendEffect(player, MobEffects.DARKNESS, 60, 0);
 
             int i = state.getValue(BITES);
             level.gameEvent(player, GameEvent.EAT, pos);
             if (i < 6) {
-                level.setBlock(pos, state.setValue(BITES, Integer.valueOf(i + 1)), 3);
+                level.setBlock(pos, state.setValue(BITES, i + 1), 3);
             } else {
                 level.removeBlock(pos, false);
                 level.gameEvent(player, GameEvent.BLOCK_DESTROY, pos);
@@ -100,5 +103,23 @@ public class PoopCakeBlock extends CakeBlock {
 
             return InteractionResult.SUCCESS;
         }
+    }
+
+    private static void addOrExtendEffect(Player player, Holder<MobEffect> effect, int duration, int amplifier) {
+    MobEffectInstance current = player.getEffect(effect);
+
+        if (current == null) {
+            player.addEffect(new MobEffectInstance(effect, duration, amplifier), player);
+            return;
+        }
+
+        player.addEffect(new MobEffectInstance(
+                effect,
+                current.getDuration() + duration,
+                Math.max(current.getAmplifier(), amplifier),
+                current.isAmbient(),
+                current.isVisible(),
+                current.showIcon()
+        ), player);
     }
 }

--- a/src/main/java/com/altnoir/poopsky/block/p/PoopCakeBlock.java
+++ b/src/main/java/com/altnoir/poopsky/block/p/PoopCakeBlock.java
@@ -1,9 +1,11 @@
 package com.altnoir.poopsky.block.p;
 
 import com.altnoir.poopsky.particle.PSParticles;
+import com.altnoir.poopsky.block.PSBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.stats.Stats;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -11,11 +13,14 @@ import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.CakeBlock;
+import net.minecraft.world.level.block.CandleBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.phys.BlockHitResult;
 
@@ -26,7 +31,27 @@ public class PoopCakeBlock extends CakeBlock {
 
     @Override
     protected ItemInteractionResult useItemOn(ItemStack stack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hitResult) {
-        return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
+        BlockState candleCake = getCandleCakeState(stack, state);
+        if (candleCake == null) {
+            return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
+        }
+
+        if (!level.isClientSide) {
+            level.playSound(null, pos, SoundEvents.CAKE_ADD_CANDLE, SoundSource.BLOCKS, 1.0F, 1.0F);
+            level.setBlockAndUpdate(pos, candleCake);
+            level.gameEvent(player, GameEvent.BLOCK_CHANGE, pos);
+            stack.consume(1, player);
+        }
+        return ItemInteractionResult.sidedSuccess(level.isClientSide);
+    }
+
+    private static BlockState getCandleCakeState(ItemStack stack, BlockState cakeState) {
+        if (cakeState.getValue(BITES) != 0 || !(stack.getItem() instanceof BlockItem blockItem)) {
+            return null;
+        }
+
+        Block candle = blockItem.getBlock();
+        return candle instanceof CandleBlock candleBlock ? PSBlocks.getPoopCandleCake(candleBlock) : null;
     }
 
     @Override

--- a/src/main/java/com/altnoir/poopsky/block/p/PoopCandleCakeBlock.java
+++ b/src/main/java/com/altnoir/poopsky/block/p/PoopCandleCakeBlock.java
@@ -1,0 +1,55 @@
+package com.altnoir.poopsky.block.p;
+
+import com.altnoir.poopsky.block.PSBlocks;
+import net.minecraft.core.BlockPos;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.CandleCakeBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.BlockHitResult;
+
+public class PoopCandleCakeBlock extends CandleCakeBlock {
+    public PoopCandleCakeBlock(Block candle, Properties properties) {
+        super(candle, properties);
+    }
+
+    @Override
+    protected InteractionResult useWithoutItem(BlockState state, Level level, BlockPos pos, Player player, BlockHitResult hitResult) {
+        if (state.getValue(LIT) && isHittingCandle(hitResult, pos)) {
+            extinguish(state, level, pos, player);
+            return InteractionResult.sidedSuccess(level.isClientSide);
+        }
+
+        return PoopCakeBlock.eat(level, pos, PSBlocks.POOP_CAKE.get().defaultBlockState(), player);
+    }
+
+    private static boolean isHittingCandle(BlockHitResult hitResult, BlockPos pos) {
+        Vec3 hitLocation = hitResult.getLocation().subtract(pos.getX(), pos.getY(), pos.getZ());
+        return hitLocation.y > 0.5
+                && hitLocation.x >= 7.0 / 16.0
+                && hitLocation.x <= 9.0 / 16.0
+                && hitLocation.z >= 7.0 / 16.0
+                && hitLocation.z <= 9.0 / 16.0;
+    }
+
+    private static void extinguish(BlockState state, Level level, BlockPos pos, Player player) {
+        if (!level.isClientSide) {
+            level.playSound(null, pos, SoundEvents.CANDLE_EXTINGUISH, SoundSource.BLOCKS, 1.0F, 1.0F);
+            level.setBlock(pos, state.setValue(LIT, false), 11);
+            level.gameEvent(player, GameEvent.BLOCK_CHANGE, pos);
+        }
+    }
+
+    @Override
+    public ItemStack getCloneItemStack(LevelReader level, BlockPos pos, BlockState state) {
+        return PSBlocks.POOP_CAKE.get().asItem().getDefaultInstance();
+    }
+}

--- a/src/main/java/com/altnoir/poopsky/block/p/PoopCandleCakeBlock.java
+++ b/src/main/java/com/altnoir/poopsky/block/p/PoopCandleCakeBlock.java
@@ -10,15 +10,61 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.CandleCakeBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.BlockHitResult;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Map;
+
 public class PoopCandleCakeBlock extends CandleCakeBlock {
+    private static final Map<Block, Block> VANILLA_CANDLE_CAKES = Map.ofEntries(
+            Map.entry(Blocks.CANDLE, Blocks.CANDLE_CAKE),
+            Map.entry(Blocks.WHITE_CANDLE, Blocks.WHITE_CANDLE_CAKE),
+            Map.entry(Blocks.ORANGE_CANDLE, Blocks.ORANGE_CANDLE_CAKE),
+            Map.entry(Blocks.MAGENTA_CANDLE, Blocks.MAGENTA_CANDLE_CAKE),
+            Map.entry(Blocks.LIGHT_BLUE_CANDLE, Blocks.LIGHT_BLUE_CANDLE_CAKE),
+            Map.entry(Blocks.YELLOW_CANDLE, Blocks.YELLOW_CANDLE_CAKE),
+            Map.entry(Blocks.LIME_CANDLE, Blocks.LIME_CANDLE_CAKE),
+            Map.entry(Blocks.PINK_CANDLE, Blocks.PINK_CANDLE_CAKE),
+            Map.entry(Blocks.GRAY_CANDLE, Blocks.GRAY_CANDLE_CAKE),
+            Map.entry(Blocks.LIGHT_GRAY_CANDLE, Blocks.LIGHT_GRAY_CANDLE_CAKE),
+            Map.entry(Blocks.CYAN_CANDLE, Blocks.CYAN_CANDLE_CAKE),
+            Map.entry(Blocks.PURPLE_CANDLE, Blocks.PURPLE_CANDLE_CAKE),
+            Map.entry(Blocks.BLUE_CANDLE, Blocks.BLUE_CANDLE_CAKE),
+            Map.entry(Blocks.BROWN_CANDLE, Blocks.BROWN_CANDLE_CAKE),
+            Map.entry(Blocks.GREEN_CANDLE, Blocks.GREEN_CANDLE_CAKE),
+            Map.entry(Blocks.RED_CANDLE, Blocks.RED_CANDLE_CAKE),
+            Map.entry(Blocks.BLACK_CANDLE, Blocks.BLACK_CANDLE_CAKE)
+    );
+
     public PoopCandleCakeBlock(Block candle, Properties properties) {
         super(candle, properties);
+        restoreVanillaCandleCake(candle);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void restoreVanillaCandleCake(Block candle) {
+        Block vanillaCandleCake = VANILLA_CANDLE_CAKES.get(candle);
+        if (vanillaCandleCake == null) {
+            return;
+        }
+
+        try {
+            for (Field field : CandleCakeBlock.class.getDeclaredFields()) {
+                if (Modifier.isStatic(field.getModifiers()) && Map.class.isAssignableFrom(field.getType())) {
+                    field.setAccessible(true);
+                    ((Map<Block, Block>) field.get(null)).put(candle, vanillaCandleCake);
+                    return;
+                }
+            }
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Unable to restore vanilla candle cake mapping", exception);
+        }
     }
 
     @Override

--- a/src/main/resources/assets/poopsky/blockstates/black_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/black_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/black_poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/black_poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/blockstates/blue_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/blue_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/blue_poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/blue_poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/blockstates/brown_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/brown_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/brown_poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/brown_poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/blockstates/cyan_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/cyan_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/cyan_poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/cyan_poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/blockstates/gray_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/gray_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/gray_poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/gray_poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/blockstates/green_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/green_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/green_poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/green_poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/blockstates/light_blue_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/light_blue_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/light_blue_poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/light_blue_poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/blockstates/light_gray_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/light_gray_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/light_gray_poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/light_gray_poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/blockstates/lime_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/lime_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/lime_poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/lime_poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/blockstates/magenta_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/magenta_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/magenta_poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/magenta_poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/blockstates/orange_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/orange_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/orange_poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/orange_poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/blockstates/pink_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/pink_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/pink_poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/pink_poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/blockstates/poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/blockstates/purple_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/purple_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/purple_poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/purple_poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/blockstates/red_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/red_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/red_poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/red_poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/blockstates/white_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/white_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/white_poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/white_poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/blockstates/yellow_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/blockstates/yellow_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "variants": {
+    "lit=false": {
+      "model": "poopsky:block/yellow_poop_candle_cake"
+    },
+    "lit=true": {
+      "model": "poopsky:block/yellow_poop_candle_cake_lit"
+    }
+  }
+}

--- a/src/main/resources/assets/poopsky/lang/en_us.json
+++ b/src/main/resources/assets/poopsky/lang/en_us.json
@@ -193,7 +193,7 @@
   "key.poopsky.down": "Descend",
 
   "advancements.poopsky.root.title": "POOPSKY",
-  "advancements.poopsky.root.description": "POOPSKY is a mod that adds a new dimension to Minecraft.",
+  "advancements.poopsky.root.description": "Start your poop empire!",
   "advancements.poopsky.poop_block_slide.title": "Master of Poop Sliding",
   "advancements.poopsky.poop_block_slide.description": "Slide on a poop block",
   "advancements.poopsky.sapling.title": "Poop Sapling",

--- a/src/main/resources/assets/poopsky/lang/zh_cn.json
+++ b/src/main/resources/assets/poopsky/lang/zh_cn.json
@@ -167,7 +167,7 @@
   "block.poopsky.light_blue_concrete_toilet": "淡蓝色混凝土厕所",
   "block.poopsky.yellow_concrete_toilet": "黄色混凝土厕所",
   "block.poopsky.lime_concrete_toilet": "黄绿色混凝土厕所",
-  "block.poopsky.pink_concrete_toilet": "粉色混凝土厕所",
+  "block.poopsky.pink_concrete_toilet": "粉红色混凝土厕所",
   "block.poopsky.gray_concrete_toilet": "灰色混凝土厕所",
   "block.poopsky.light_gray_concrete_toilet": "淡灰色混凝土厕所",
   "block.poopsky.cyan_concrete_toilet": "青色混凝土厕所",

--- a/src/main/resources/assets/poopsky/models/block/black_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/black_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/black_candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/black_poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/black_poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/black_candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/blue_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/blue_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/blue_candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/blue_poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/blue_poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/blue_candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/brown_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/brown_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/brown_candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/brown_poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/brown_poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/brown_candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/cyan_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/cyan_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/cyan_candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/cyan_poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/cyan_poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/cyan_candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/gray_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/gray_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/gray_candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/gray_poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/gray_poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/gray_candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/green_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/green_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/green_candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/green_poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/green_poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/green_candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/light_blue_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/light_blue_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/light_blue_candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/light_blue_poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/light_blue_poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/light_blue_candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/light_gray_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/light_gray_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/light_gray_candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/light_gray_poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/light_gray_poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/light_gray_candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/lime_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/lime_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/lime_candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/lime_poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/lime_poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/lime_candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/magenta_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/magenta_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/magenta_candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/magenta_poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/magenta_poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/magenta_candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/orange_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/orange_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/orange_candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/orange_poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/orange_poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/orange_candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/pink_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/pink_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/pink_candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/pink_poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/pink_poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/pink_candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/purple_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/purple_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/purple_candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/purple_poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/purple_poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/purple_candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/red_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/red_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/red_candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/red_poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/red_poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/red_candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/white_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/white_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/white_candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/white_poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/white_poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/white_candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/yellow_poop_candle_cake.json
+++ b/src/main/resources/assets/poopsky/models/block/yellow_poop_candle_cake.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/yellow_candle",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/assets/poopsky/models/block/yellow_poop_candle_cake_lit.json
+++ b/src/main/resources/assets/poopsky/models/block/yellow_poop_candle_cake_lit.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/template_cake_with_candle",
+  "textures": {
+    "bottom": "poopsky:block/poop_cake_bottom",
+    "candle": "minecraft:block/yellow_candle_lit",
+    "particle": "poopsky:block/poop_cake_side",
+    "side": "poopsky:block/poop_cake_side",
+    "top": "poopsky:block/poop_cake_top"
+  }
+}

--- a/src/main/resources/data/minecraft/tags/block/candle_cakes.json
+++ b/src/main/resources/data/minecraft/tags/block/candle_cakes.json
@@ -1,0 +1,22 @@
+{
+  "replace": false,
+  "values": [
+    "poopsky:poop_candle_cake",
+    "poopsky:white_poop_candle_cake",
+    "poopsky:orange_poop_candle_cake",
+    "poopsky:magenta_poop_candle_cake",
+    "poopsky:light_blue_poop_candle_cake",
+    "poopsky:yellow_poop_candle_cake",
+    "poopsky:lime_poop_candle_cake",
+    "poopsky:pink_poop_candle_cake",
+    "poopsky:gray_poop_candle_cake",
+    "poopsky:light_gray_poop_candle_cake",
+    "poopsky:cyan_poop_candle_cake",
+    "poopsky:purple_poop_candle_cake",
+    "poopsky:blue_poop_candle_cake",
+    "poopsky:brown_poop_candle_cake",
+    "poopsky:green_poop_candle_cake",
+    "poopsky:red_poop_candle_cake",
+    "poopsky:black_poop_candle_cake"
+  ]
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/black_poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/black_poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/black_poop_candle_cake"
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/blue_poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/blue_poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/blue_poop_candle_cake"
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/brown_poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/brown_poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/brown_poop_candle_cake"
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/cyan_poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/cyan_poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/cyan_poop_candle_cake"
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/gray_poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/gray_poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/gray_poop_candle_cake"
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/green_poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/green_poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/green_poop_candle_cake"
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/light_blue_poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/light_blue_poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/light_blue_poop_candle_cake"
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/light_gray_poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/light_gray_poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/light_gray_poop_candle_cake"
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/lime_poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/lime_poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/lime_poop_candle_cake"
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/magenta_poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/magenta_poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/magenta_poop_candle_cake"
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/orange_poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/orange_poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/orange_poop_candle_cake"
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/pink_poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/pink_poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/pink_poop_candle_cake"
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/poop_candle_cake"
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/purple_poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/purple_poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/purple_poop_candle_cake"
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/red_poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/red_poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/red_poop_candle_cake"
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/white_poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/white_poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/white_poop_candle_cake"
+}

--- a/src/main/resources/data/poopsky/loot_table/blocks/yellow_poop_candle_cake.json
+++ b/src/main/resources/data/poopsky/loot_table/blocks/yellow_poop_candle_cake.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "poopsky:poop_cake"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "poopsky:blocks/yellow_poop_candle_cake"
+}


### PR DESCRIPTION
- 粪便蛋糕继承新增放蜡烛、点燃、比较器输出信号等原版蜡烛蛋糕行为
- 修复粪便蛋糕右键不会放蜡烛的问题
- 修复粪便蛋糕每次吃都重置效果，现在效果时间会累加

![2026-06-01_19.53.59.png](https://github.com/user-attachments/assets/7e404afb-be5e-4b28-baa8-f24c56456ac2)

