### PR TITLE
Modify license information in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ The output artifact will be in `build/libs/`.
 
 ## License
 
-MIT
+cod: MIT
+art: CC0
 
 ## Authors
 


### PR DESCRIPTION
Updated license section to include CC0 alongside MIT.