### PR TITLE
fix dedicated server crash, worldgen class cast exception, and effect explosion loop

### DIFF
--- a/src/main/java/com/altnoir/poopsky/content/block/p/SaltpeterClusterBlock.java
+++ b/src/main/java/com/altnoir/poopsky/content/block/p/SaltpeterClusterBlock.java
@@ -44,7 +44,7 @@ public class SaltpeterClusterBlock extends AmethystClusterBlock implements Bonem
 
     @Override
     protected BlockState updateShape(BlockState state, Direction direction, BlockState neighborState, LevelAccessor level, BlockPos pos, BlockPos neighborPos) {
-        isDone((Level) level, pos, state);
+        isDone(level, pos, state);
         return super.updateShape(state, direction, neighborState, level, pos, neighborPos);
     }
 
@@ -54,7 +54,7 @@ public class SaltpeterClusterBlock extends AmethystClusterBlock implements Bonem
         super.onPlace(state, level, pos, oldState, movedByPiston);
     }
 
-    private void isDone(Level level, BlockPos pos, BlockState state) {
+    private void isDone(LevelAccessor level, BlockPos pos, BlockState state) {
         if (!level.isClientSide() && state.is(PoBlocks.SALTPETER_CLUSTER.get()) && state.getValue(BlockStateProperties.WATERLOGGED)) {
             level.scheduleTick(pos, this, 4);
         }

--- a/src/main/java/com/altnoir/poopsky/content/effect/OnTheVergeEffect.java
+++ b/src/main/java/com/altnoir/poopsky/content/effect/OnTheVergeEffect.java
@@ -59,6 +59,7 @@ public class OnTheVergeEffect extends MobEffect {
             }
             if (amplifier >= 1 && duration > 200) {
                 openTheDoor = true;
+                result = true;
             }
 
             if (openTheDoor) {

--- a/src/main/java/com/altnoir/poopsky/content/item/p/TimeBellItem.java
+++ b/src/main/java/com/altnoir/poopsky/content/item/p/TimeBellItem.java
@@ -90,7 +90,7 @@ public class TimeBellItem extends Item {
 
         int usedTicks = this.getUseDuration(stack, livingEntity) - timeLeft;
 
-        if (usedTicks < DELAY_TICKS) {
+        if (level.isClientSide && usedTicks < DELAY_TICKS) {
             Minecraft.getInstance().getSoundManager().stop(PoSoundEvents.ITEM_TIME_BELL_OPEN.get().getLocation(), SoundSource.PLAYERS);
         }
     }


### PR DESCRIPTION
- added client-side check before stopping sound manager in `TimeBellItem.releaseUsing` to prevent dedicated server crashes
- changed `SaltpeterClusterBlock.isDone` parameter to `LevelAccessor` to prevent `ClassCastException` during worldgen chunk population
- marked `OnTheVergeEffect` for removal when an amplified explosion triggers to avoid repeated detonations every tick